### PR TITLE
fix bug introduced by Pandas 1.0.3

### DIFF
--- a/demo_profile_functions/demo_profile_functions.py
+++ b/demo_profile_functions/demo_profile_functions.py
@@ -353,7 +353,7 @@ def wrangle_summs_into_long_format(summs_, demos_list, verbose=False):
         transposed = transposed[~transposed.measure.isna() & transposed.demo_code.isin(all_demo_codes)]
         pvt = transposed.pivot(index='demo_code',columns='measure',values='value').reset_index()
         # Caution, something weird happens with the dtypes during this pivot, so be careful. see: https://stackoverflow.com/questions/46859400/pandas-pivot-changes-dtype
-        del pvt.columns.name
+        pvt.columns.name = None
         pvt['brands'] = brands
         data_summary_list.append(pvt)
 


### PR DESCRIPTION
See this [stackoverflow](https://stackoverflow.com/questions/53036910/pandas-remove-the-label-of-the-column-index/53036951)

Previously [this was the correct behavior](https://stackoverflow.com/a/53036944/2098573), 

but it stopped working in Pandas 1.0.3 and [now this is the correct solution](https://stackoverflow.com/a/61312610/2098573). 

